### PR TITLE
dont wait for confirms

### DIFF
--- a/lib/promiscuous/amqp/bunny.rb
+++ b/lib/promiscuous/amqp/bunny.rb
@@ -89,13 +89,13 @@ class Promiscuous::AMQP::Bunny
 
       raw_publish(options)
 
-      unless options[:async]
-        if @channel.wait_for_confirms
-          options[:on_confirm].call if options[:on_confirm]
-        else
-          raise Promiscuous::Error::PublishUnacknowledged.new(options[:payload])
-        end
-      end
+      # unless options[:async]
+      #   if @channel.wait_for_confirms
+      #     options[:on_confirm].call if options[:on_confirm]
+      #   else
+      #     raise Promiscuous::Error::PublishUnacknowledged.new(options[:payload])
+      #   end
+      # end
     end
   rescue Exception => e
     Promiscuous.warn("[publish] Failure publishing to rabbit #{e}\n#{e.backtrace.join("\n")}")


### PR DESCRIPTION
this patch prevents raise err of unacknowledged msg sent to rabbitmq
this does not stop real errors from the publish event from being raised, it just eliminates the waiting for confirm from rabbitmq thru the bunny gem that promiscuous uses.

this is a patch and we can investigate further what the root cause of the timeout in acks may be
